### PR TITLE
Create blank files to represent directories

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -130,6 +130,8 @@ class AzureBlobStorageAdapter extends AbstractAdapter
 
     public function createDir($dirname, Config $config)
     {
+        $this->upload($dirname . '/', '', $config);                                                                                      
+
         return ['path' => $dirname, 'type' => 'dir'];
     }
 


### PR DESCRIPTION
This, in line with the league/flysystem-aws-s3-v3 S3 adapter, creates a blank blob called '/' to represent the directory.